### PR TITLE
update calibration for v1.5

### DIFF
--- a/share/cuhk-daVinci/sawRobotIO1394-ECM-29738.xml
+++ b/share/cuhk-daVinci/sawRobotIO1394-ECM-29738.xml
@@ -3,18 +3,18 @@
    <Robot Name="ECM" NumOfActuator="4" NumOfJoint="4" SN="29738">
       <Actuator ActuatorID="0" AxisID="0" BoardID="4" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32782" Scale="5242.88"/>
-            <BitsToFeedbackAmps Offset="-6.246109" Scale="0.000190738"/>
+            <AmpsToBits Offset="32780" Scale="5242.88"/>
+            <BitsToFeedbackAmps Offset="-6.246136" Scale="0.000190738"/>
             <NmToAmps Scale="0.035014"/>
             <MaxCurrent Unit="A" Value="0.943"/>
          </Drive>
          <AnalogBrake AxisID="0" BoardID="5">
-            <AmpsToBits Offset="32861" Scale="5242.88"/>
-            <BitsToFeedbackAmps Offset="-6.246381" Scale="0.000190738"/>
+            <AmpsToBits Offset="32768" Scale="5242.88"/>
+            <BitsToFeedbackAmps Offset="-6.25" Scale="0.000190738"/>
             <MaxCurrent Unit="A" Value="0.250"/>
-            <ReleaseCurrent Unit="A" Value="0.25"/>
-            <ReleaseTime Value="0.200"/>
-            <ReleasedCurrent Unit="A" Value="0.1"/>
+            <ReleaseCurrent Unit="A" Value="0.250"/>
+            <ReleaseTime Value="2.000"/>
+            <ReleasedCurrent Unit="A" Value="0.080"/>
             <EngagedCurrent Unit="A" Value="0.000"/>
          </AnalogBrake>
          <Encoder>
@@ -30,18 +30,18 @@
       </Actuator>
       <Actuator ActuatorID="1" AxisID="1" BoardID="4" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32792" Scale="5242.88"/>
-            <BitsToFeedbackAmps Offset="-6.243509" Scale="0.000190738"/>
+            <AmpsToBits Offset="32790" Scale="5242.88"/>
+            <BitsToFeedbackAmps Offset="-6.243317" Scale="0.000190738"/>
             <NmToAmps Scale="0.035014"/>
             <MaxCurrent Unit="A" Value="0.943"/>
          </Drive>
          <AnalogBrake AxisID="1" BoardID="5">
-            <AmpsToBits Offset="32795" Scale="5242.88"/>
-            <BitsToFeedbackAmps Offset="-6.258586" Scale="0.000190738"/>
+            <AmpsToBits Offset="32768" Scale="5242.88"/>
+            <BitsToFeedbackAmps Offset="-6.25" Scale="0.000190738"/>
             <MaxCurrent Unit="A" Value="0.220"/>
-            <ReleaseCurrent Unit="A" Value="0.22"/>
-            <ReleaseTime Value="0.200"/>
-            <ReleasedCurrent Unit="A" Value="0.1"/>
+            <ReleaseCurrent Unit="A" Value="0.220"/>
+            <ReleaseTime Value="2.000"/>
+            <ReleasedCurrent Unit="A" Value="0.070"/>
             <EngagedCurrent Unit="A" Value="0.000"/>
          </AnalogBrake>
          <Encoder>
@@ -58,17 +58,17 @@
       <Actuator ActuatorID="2" AxisID="2" BoardID="4" Type="Prismatic">
          <Drive>
             <AmpsToBits Offset="32766" Scale="-5242.88"/>
-            <BitsToFeedbackAmps Offset="6.235516" Scale="-0.000190738"/>
+            <BitsToFeedbackAmps Offset="6.235430" Scale="-0.000190738"/>
             <NmToAmps Scale="0.008307"/>
             <MaxCurrent Unit="A" Value="0.670"/>
          </Drive>
          <AnalogBrake AxisID="2" BoardID="5">
-            <AmpsToBits Offset="32791" Scale="5242.88"/>
-            <BitsToFeedbackAmps Offset="-6.238126" Scale="0.000190738"/>
+            <AmpsToBits Offset="32768" Scale="5242.88"/>
+            <BitsToFeedbackAmps Offset="-6.25" Scale="0.000190738"/>
             <MaxCurrent Unit="A" Value="0.900"/>
-            <ReleaseCurrent Unit="A" Value="1.2"/>
-            <ReleaseTime Value="0.200"/>
-            <ReleasedCurrent Unit="A" Value="0.3"/>
+            <ReleaseCurrent Unit="A" Value="0.900"/>
+            <ReleaseTime Value="2.000"/>
+            <ReleasedCurrent Unit="A" Value="0.200"/>
             <EngagedCurrent Unit="A" Value="0.000"/>
          </AnalogBrake>
          <Encoder>
@@ -84,8 +84,8 @@
       </Actuator>
       <Actuator ActuatorID="3" AxisID="3" BoardID="4" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32771" Scale="5242.88"/>
-            <BitsToFeedbackAmps Offset="-6.255262" Scale="0.000190738"/>
+            <AmpsToBits Offset="32770" Scale="5242.88"/>
+            <BitsToFeedbackAmps Offset="-6.255151" Scale="0.000190738"/>
             <NmToAmps Scale="0.673064"/>
             <MaxCurrent Unit="A" Value="0.590"/>
          </Drive>
@@ -100,7 +100,12 @@
             <VoltsToPosSI Offset="102.142275" Scale="-45.424298"/>
          </AnalogIn>
       </Actuator>
-      <Potentiometers Position="Actuators"/>
+      <Potentiometers Position="Actuators">
+         <Tolerance Axis="0" Distance="5.00" Latency="0.01" Unit="deg"/>
+         <Tolerance Axis="1" Distance="5.00" Latency="0.01" Unit="deg"/>
+         <Tolerance Axis="2" Distance="5.00" Latency="0.01" Unit="mm"/>
+         <Tolerance Axis="3" Distance="5.00" Latency="0.01" Unit="deg"/>
+      </Potentiometers>
    </Robot><!--Digital Input Configuration-->
    <DigitalIn BitID="0" BoardID="4" Debounce="0.2" Name="ECM-ManipClutch" Pressed="1" Trigger="all"/>
    <DigitalIn BitID="2" BoardID="4" Debounce="0.2" Name="ECM-SUJClutch" Pressed="1" Trigger="all"/>

--- a/share/cuhk-daVinci/sawRobotIO1394-ECM-29738.xml
+++ b/share/cuhk-daVinci/sawRobotIO1394-ECM-29738.xml
@@ -3,18 +3,18 @@
    <Robot Name="ECM" NumOfActuator="4" NumOfJoint="4" SN="29738">
       <Actuator ActuatorID="0" AxisID="0" BoardID="4" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32780" Scale="5242.88"/>
-            <BitsToFeedbackAmps Offset="-6.246136" Scale="0.000190738"/>
+            <AmpsToBits Offset="32782" Scale="5242.88"/>
+            <BitsToFeedbackAmps Offset="-6.246109" Scale="0.000190738"/>
             <NmToAmps Scale="0.035014"/>
             <MaxCurrent Unit="A" Value="0.943"/>
          </Drive>
          <AnalogBrake AxisID="0" BoardID="5">
-            <AmpsToBits Offset="32768" Scale="5242.88"/>
-            <BitsToFeedbackAmps Offset="-6.25" Scale="0.000190738"/>
+            <AmpsToBits Offset="32861" Scale="5242.88"/>
+            <BitsToFeedbackAmps Offset="-6.246381" Scale="0.000190738"/>
             <MaxCurrent Unit="A" Value="0.250"/>
-            <ReleaseCurrent Unit="A" Value="0.250"/>
-            <ReleaseTime Value="2.000"/>
-            <ReleasedCurrent Unit="A" Value="0.080"/>
+            <ReleaseCurrent Unit="A" Value="0.25"/>
+            <ReleaseTime Value="0.200"/>
+            <ReleasedCurrent Unit="A" Value="0.1"/>
             <EngagedCurrent Unit="A" Value="0.000"/>
          </AnalogBrake>
          <Encoder>
@@ -30,18 +30,18 @@
       </Actuator>
       <Actuator ActuatorID="1" AxisID="1" BoardID="4" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32790" Scale="5242.88"/>
-            <BitsToFeedbackAmps Offset="-6.243317" Scale="0.000190738"/>
+            <AmpsToBits Offset="32792" Scale="5242.88"/>
+            <BitsToFeedbackAmps Offset="-6.243509" Scale="0.000190738"/>
             <NmToAmps Scale="0.035014"/>
             <MaxCurrent Unit="A" Value="0.943"/>
          </Drive>
          <AnalogBrake AxisID="1" BoardID="5">
-            <AmpsToBits Offset="32768" Scale="5242.88"/>
-            <BitsToFeedbackAmps Offset="-6.25" Scale="0.000190738"/>
+            <AmpsToBits Offset="32795" Scale="5242.88"/>
+            <BitsToFeedbackAmps Offset="-6.258586" Scale="0.000190738"/>
             <MaxCurrent Unit="A" Value="0.220"/>
-            <ReleaseCurrent Unit="A" Value="0.220"/>
-            <ReleaseTime Value="2.000"/>
-            <ReleasedCurrent Unit="A" Value="0.070"/>
+            <ReleaseCurrent Unit="A" Value="0.22"/>
+            <ReleaseTime Value="0.200"/>
+            <ReleasedCurrent Unit="A" Value="0.1"/>
             <EngagedCurrent Unit="A" Value="0.000"/>
          </AnalogBrake>
          <Encoder>
@@ -58,17 +58,17 @@
       <Actuator ActuatorID="2" AxisID="2" BoardID="4" Type="Prismatic">
          <Drive>
             <AmpsToBits Offset="32766" Scale="-5242.88"/>
-            <BitsToFeedbackAmps Offset="6.235430" Scale="-0.000190738"/>
+            <BitsToFeedbackAmps Offset="6.235516" Scale="-0.000190738"/>
             <NmToAmps Scale="0.008307"/>
             <MaxCurrent Unit="A" Value="0.670"/>
          </Drive>
          <AnalogBrake AxisID="2" BoardID="5">
-            <AmpsToBits Offset="32768" Scale="5242.88"/>
-            <BitsToFeedbackAmps Offset="-6.25" Scale="0.000190738"/>
+            <AmpsToBits Offset="32791" Scale="5242.88"/>
+            <BitsToFeedbackAmps Offset="-6.238126" Scale="0.000190738"/>
             <MaxCurrent Unit="A" Value="0.900"/>
-            <ReleaseCurrent Unit="A" Value="0.900"/>
-            <ReleaseTime Value="2.000"/>
-            <ReleasedCurrent Unit="A" Value="0.200"/>
+            <ReleaseCurrent Unit="A" Value="1.2"/>
+            <ReleaseTime Value="0.200"/>
+            <ReleasedCurrent Unit="A" Value="0.3"/>
             <EngagedCurrent Unit="A" Value="0.000"/>
          </AnalogBrake>
          <Encoder>
@@ -84,8 +84,8 @@
       </Actuator>
       <Actuator ActuatorID="3" AxisID="3" BoardID="4" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32770" Scale="5242.88"/>
-            <BitsToFeedbackAmps Offset="-6.255151" Scale="0.000190738"/>
+            <AmpsToBits Offset="32771" Scale="5242.88"/>
+            <BitsToFeedbackAmps Offset="-6.255262" Scale="0.000190738"/>
             <NmToAmps Scale="0.673064"/>
             <MaxCurrent Unit="A" Value="0.590"/>
          </Drive>

--- a/share/cuhk-daVinci/sawRobotIO1394-MTML-41878.xml
+++ b/share/cuhk-daVinci/sawRobotIO1394-MTML-41878.xml
@@ -2,8 +2,8 @@
    <Robot Name="MTML" NumOfActuator="8" NumOfJoint="8" SN="41878">
       <Actuator ActuatorID="0" AxisID="0" BoardID="0" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32908" Scale="-5242.88" />
-            <BitsToFeedbackAmps Offset="6.255714" Scale="-0.000190738" />
+            <AmpsToBits Offset="32909" Scale="-5242.88" />
+            <BitsToFeedbackAmps Offset="6.255975" Scale="-0.000190738" />
             <NmToAmps Scale="0.360054" />
             <MaxCurrent Unit="A" Value="0.670" />
          </Drive>
@@ -15,13 +15,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="-158.630672275" Scale="76.2451470817" />
+            <VoltsToPosSI Offset="-159.318031698" Scale="76.291553298" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="1" AxisID="1" BoardID="0" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32846" Scale="5242.88" />
-            <BitsToFeedbackAmps Offset="-6.246821" Scale="0.000190738" />
+            <AmpsToBits Offset="32847" Scale="5242.88" />
+            <BitsToFeedbackAmps Offset="-6.246978" Scale="0.000190738" />
             <NmToAmps Scale="0.457720" />
             <MaxCurrent Unit="A" Value="0.670" />
          </Drive>
@@ -33,13 +33,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="-145.710701227" Scale="76.2813361021" />
+            <VoltsToPosSI Offset="-145.03392911" Scale="76.2565824569" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="2" AxisID="2" BoardID="0" Type="Revolute">
          <Drive>
             <AmpsToBits Offset="32837" Scale="5242.88" />
-            <BitsToFeedbackAmps Offset="-6.266022" Scale="0.000190738" />
+            <BitsToFeedbackAmps Offset="-6.265968" Scale="0.000190738" />
             <NmToAmps Scale="0.382238" />
             <MaxCurrent Unit="A" Value="0.670" />
          </Drive>
@@ -51,13 +51,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="-167.592484153" Scale="76.2303012871" />
+            <VoltsToPosSI Offset="-167.058120532" Scale="76.2045326552" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="3" AxisID="3" BoardID="0" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32883" Scale="5242.88" />
-            <BitsToFeedbackAmps Offset="-6.231840" Scale="0.000190738" />
+            <AmpsToBits Offset="32881" Scale="5242.88" />
+            <BitsToFeedbackAmps Offset="-6.231632" Scale="0.000190738" />
             <NmToAmps Scale="2.168191" />
             <MaxCurrent Unit="A" Value="0.670" />
          </Drive>
@@ -69,13 +69,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="117.62436806" Scale="-76.8021216086" />
+            <VoltsToPosSI Offset="118.23395317" Scale="-76.794139831" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="4" AxisID="0" BoardID="1" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32763" Scale="-5242.88" />
-            <BitsToFeedbackAmps Offset="6.250504" Scale="-0.000190738" />
+            <AmpsToBits Offset="32762" Scale="-5242.88" />
+            <BitsToFeedbackAmps Offset="6.250400" Scale="-0.000190738" />
             <NmToAmps Scale="6.092286" />
             <MaxCurrent Unit="A" Value="0.590" />
          </Drive>
@@ -87,13 +87,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="225.177801691" Scale="-79.1559965515" />
+            <VoltsToPosSI Offset="224.630083625" Scale="-79.1000675306" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="5" AxisID="1" BoardID="1" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32788" Scale="5242.88" />
-            <BitsToFeedbackAmps Offset="-6.223447" Scale="0.000190738" />
+            <AmpsToBits Offset="32789" Scale="5242.88" />
+            <BitsToFeedbackAmps Offset="-6.223621" Scale="0.000190738" />
             <NmToAmps Scale="6.092286" />
             <MaxCurrent Unit="A" Value="0.590" />
          </Drive>
@@ -105,13 +105,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="-182.586571937" Scale="79.198116577" />
+            <VoltsToPosSI Offset="-181.490761433" Scale="79.0691465861" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="6" AxisID="2" BoardID="1" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32917" Scale="-5242.88" />
-            <BitsToFeedbackAmps Offset="6.242356" Scale="-0.000190738" />
+            <AmpsToBits Offset="32918" Scale="-5242.88" />
+            <BitsToFeedbackAmps Offset="6.242370" Scale="-0.000190738" />
             <NmToAmps Scale="17.791632" />
             <MaxCurrent Unit="A" Value="0.407" />
          </Drive>
@@ -123,13 +123,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="89.8338294465" Scale="-40.8869941061" />
+            <VoltsToPosSI Offset="87.1585901161" Scale="-40.8904192635" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="7" AxisID="3" BoardID="1" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32770" Scale="5242.88" />
-            <BitsToFeedbackAmps Offset="-6.256093" Scale="0.000190738" />
+            <AmpsToBits Offset="32771" Scale="5242.88" />
+            <BitsToFeedbackAmps Offset="-6.256341" Scale="0.000190738" />
             <NmToAmps Scale="1.000000" />
             <MaxCurrent Unit="A" Value="0.000" />
          </Drive>
@@ -141,10 +141,19 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="415.623765" Scale="-132.778105" />
+            <VoltsToPosSI Offset="402.562225" Scale="-127.937439" />
          </AnalogIn>
       </Actuator>
-      <Potentiometers Position="Joints" />
+      <Potentiometers Position="Joints">
+         <Tolerance Axis="0" Distance="5.00" Latency="0.01" Unit="deg" />
+         <Tolerance Axis="1" Distance="5.00" Latency="0.01" Unit="deg" />
+         <Tolerance Axis="2" Distance="5.00" Latency="0.01" Unit="deg" />
+         <Tolerance Axis="3" Distance="5.00" Latency="0.01" Unit="deg" />
+         <Tolerance Axis="4" Distance="5.00" Latency="0.01" Unit="deg" />
+         <Tolerance Axis="5" Distance="5.00" Latency="0.01" Unit="deg" />
+         <Tolerance Axis="6" Distance="1000.00" Latency="0.01" Unit="deg" />
+         <Tolerance Axis="7" Distance="1000.00" Latency="0.01" Unit="deg" />
+      </Potentiometers>
       <Coupling Value="1">
          <ActuatorToJointPosition>
             <Row Val="1.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000" />
@@ -156,36 +165,6 @@
             <Row Val="0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 1.0000 0.0000" />
             <Row Val="0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 1.0000" />
          </ActuatorToJointPosition>
-         <JointToActuatorPosition>
-            <Row Val="1.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 1.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 1.0000 1.0000 0.0000 0.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.6697 1.0000 0.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 0.0000 1.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 0.0000 0.0000 1.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 1.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 1.0000" />
-         </JointToActuatorPosition>
-         <ActuatorToJointTorque>
-            <Row Val="1.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 1.0000 1.0000 0.0000 0.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 1.0000 0.6697 0.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 1.0000 0.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 0.0000 1.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 0.0000 0.0000 1.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 1.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 1.0000" />
-         </ActuatorToJointTorque>
-         <JointToActuatorTorque>
-            <Row Val="1.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 1.0000 -1.0000 0.6697 0.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 1.0000 -0.6697 0.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 1.0000 0.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 0.0000 1.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 0.0000 0.0000 1.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 1.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 1.0000" />
-         </JointToActuatorTorque>
       </Coupling>
    </Robot>
 </Config>

--- a/share/cuhk-daVinci/sawRobotIO1394-MTMR-31519.xml
+++ b/share/cuhk-daVinci/sawRobotIO1394-MTMR-31519.xml
@@ -2,8 +2,8 @@
    <Robot Name="MTMR" NumOfActuator="8" NumOfJoint="8" SN="31519">
       <Actuator ActuatorID="0" AxisID="0" BoardID="2" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32840" Scale="-5242.88" />
-            <BitsToFeedbackAmps Offset="6.233401" Scale="-0.000190738" />
+            <AmpsToBits Offset="32841" Scale="-5242.88" />
+            <BitsToFeedbackAmps Offset="6.233339" Scale="-0.000190738" />
             <NmToAmps Scale="0.360054" />
             <MaxCurrent Unit="A" Value="0.670" />
          </Drive>
@@ -15,13 +15,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="-187.833720757" Scale="76.9471640153" />
+            <VoltsToPosSI Offset="-188.185686961" Scale="76.9702852098" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="1" AxisID="1" BoardID="2" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32897" Scale="5242.88" />
-            <BitsToFeedbackAmps Offset="-6.241045" Scale="0.000190738" />
+            <AmpsToBits Offset="32900" Scale="5242.88" />
+            <BitsToFeedbackAmps Offset="-6.241430" Scale="0.000190738" />
             <NmToAmps Scale="0.457720" />
             <MaxCurrent Unit="A" Value="0.670" />
          </Drive>
@@ -33,13 +33,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="-143.817949127" Scale="75.920628896" />
+            <VoltsToPosSI Offset="-144.228848974" Scale="75.9203172895" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="2" AxisID="2" BoardID="2" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32841" Scale="5242.88" />
-            <BitsToFeedbackAmps Offset="-6.240853" Scale="0.000190738" />
+            <AmpsToBits Offset="32838" Scale="5242.88" />
+            <BitsToFeedbackAmps Offset="-6.240110" Scale="0.000190738" />
             <NmToAmps Scale="0.382238" />
             <MaxCurrent Unit="A" Value="0.670" />
          </Drive>
@@ -51,13 +51,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="-163.273537211" Scale="74.9374659213" />
+            <VoltsToPosSI Offset="-163.544487765" Scale="74.9454435692" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="3" AxisID="3" BoardID="2" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32917" Scale="5242.88" />
-            <BitsToFeedbackAmps Offset="-6.269328" Scale="0.000190738" />
+            <AmpsToBits Offset="32920" Scale="5242.88" />
+            <BitsToFeedbackAmps Offset="-6.269326" Scale="0.000190738" />
             <NmToAmps Scale="2.168191" />
             <MaxCurrent Unit="A" Value="0.670" />
          </Drive>
@@ -69,13 +69,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="226.184468747" Scale="-77.0819671174" />
+            <VoltsToPosSI Offset="225.626619439" Scale="-77.0860851312" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="4" AxisID="0" BoardID="3" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32952" Scale="5242.88" />
-            <BitsToFeedbackAmps Offset="-6.257121" Scale="0.000190738" />
+            <AmpsToBits Offset="32956" Scale="5242.88" />
+            <BitsToFeedbackAmps Offset="-6.257901" Scale="0.000190738" />
             <NmToAmps Scale="6.092286" />
             <MaxCurrent Unit="A" Value="0.590" />
          </Drive>
@@ -87,13 +87,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="-132.448259372" Scale="79.363729874" />
+            <VoltsToPosSI Offset="-132.173145035" Scale="79.3107454933" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="5" AxisID="1" BoardID="3" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32921" Scale="5242.88" />
-            <BitsToFeedbackAmps Offset="-6.249984" Scale="0.000190738" />
+            <AmpsToBits Offset="32919" Scale="5242.88" />
+            <BitsToFeedbackAmps Offset="-6.250729" Scale="0.000190738" />
             <NmToAmps Scale="6.092286" />
             <MaxCurrent Unit="A" Value="0.590" />
          </Drive>
@@ -105,13 +105,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="-173.183090355" Scale="79.8852984949" />
+            <VoltsToPosSI Offset="-178.000319618" Scale="79.7772056287" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="6" AxisID="2" BoardID="3" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32827" Scale="-5242.88" />
-            <BitsToFeedbackAmps Offset="6.248606" Scale="-0.000190738" />
+            <AmpsToBits Offset="32829" Scale="-5242.88" />
+            <BitsToFeedbackAmps Offset="6.249128" Scale="-0.000190738" />
             <NmToAmps Scale="17.791632" />
             <MaxCurrent Unit="A" Value="0.407" />
          </Drive>
@@ -123,13 +123,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="-105.083294696" Scale="41.3769395548" />
+            <VoltsToPosSI Offset="-108.921066953" Scale="41.4415835122" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="7" AxisID="3" BoardID="3" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32914" Scale="5242.88" />
-            <BitsToFeedbackAmps Offset="-6.272111" Scale="0.000190738" />
+            <AmpsToBits Offset="32868" Scale="5242.88" />
+            <BitsToFeedbackAmps Offset="-6.272590" Scale="0.000190738" />
             <NmToAmps Scale="1.000000" />
             <MaxCurrent Unit="A" Value="0.000" />
          </Drive>
@@ -141,10 +141,19 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="310.807692" Scale="-93.356058" />
+            <VoltsToPosSI Offset="312.137872" Scale="-93.827199" />
          </AnalogIn>
       </Actuator>
-      <Potentiometers Position="Joints" />
+      <Potentiometers Position="Joints">
+         <Tolerance Axis="0" Distance="5.00" Latency="0.01" Unit="deg" />
+         <Tolerance Axis="1" Distance="5.00" Latency="0.01" Unit="deg" />
+         <Tolerance Axis="2" Distance="5.00" Latency="0.01" Unit="deg" />
+         <Tolerance Axis="3" Distance="5.00" Latency="0.01" Unit="deg" />
+         <Tolerance Axis="4" Distance="5.00" Latency="0.01" Unit="deg" />
+         <Tolerance Axis="5" Distance="5.00" Latency="0.01" Unit="deg" />
+         <Tolerance Axis="6" Distance="1000.00" Latency="0.01" Unit="deg" />
+         <Tolerance Axis="7" Distance="1000.00" Latency="0.01" Unit="deg" />
+      </Potentiometers>
       <Coupling Value="1">
          <ActuatorToJointPosition>
             <Row Val="1.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000" />
@@ -156,36 +165,6 @@
             <Row Val="0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 1.0000 0.0000" />
             <Row Val="0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 1.0000" />
          </ActuatorToJointPosition>
-         <JointToActuatorPosition>
-            <Row Val="1.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 1.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 1.0000 1.0000 0.0000 0.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.6697 1.0000 0.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 0.0000 1.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 0.0000 0.0000 1.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 1.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 1.0000" />
-         </JointToActuatorPosition>
-         <ActuatorToJointTorque>
-            <Row Val="1.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 1.0000 1.0000 0.0000 0.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 1.0000 0.6697 0.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 1.0000 0.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 0.0000 1.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 0.0000 0.0000 1.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 1.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 1.0000" />
-         </ActuatorToJointTorque>
-         <JointToActuatorTorque>
-            <Row Val="1.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 1.0000 -1.0000 0.6697 0.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 1.0000 -0.6697 0.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 1.0000 0.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 0.0000 1.0000 0.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 0.0000 0.0000 1.0000 0.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 1.0000 0.0000" />
-            <Row Val="0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 0.0000 1.0000" />
-         </JointToActuatorTorque>
       </Coupling>
    </Robot>
 </Config>

--- a/share/cuhk-daVinci/sawRobotIO1394-PSM1-28124.xml
+++ b/share/cuhk-daVinci/sawRobotIO1394-PSM1-28124.xml
@@ -3,7 +3,7 @@
       <Actuator ActuatorID="0" AxisID="0" BoardID="6" Type="Revolute">
          <Drive>
             <AmpsToBits Offset="32891" Scale="-5242.88" />
-            <BitsToFeedbackAmps Offset="6.259754" Scale="-0.000190738" />
+            <BitsToFeedbackAmps Offset="6.259864" Scale="-0.000190738" />
             <NmToAmps Scale="0.404089" />
             <MaxCurrent Unit="A" Value="1.340" />
          </Drive>
@@ -15,13 +15,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="99.9476203287" Scale="-43.6138323017" />
+            <VoltsToPosSI Offset="99.946758" Scale="-43.6100563233" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="1" AxisID="1" BoardID="6" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32888" Scale="-5242.88" />
-            <BitsToFeedbackAmps Offset="6.246941" Scale="-0.000190738" />
+            <AmpsToBits Offset="32889" Scale="-5242.88" />
+            <BitsToFeedbackAmps Offset="6.247143" Scale="-0.000190738" />
             <NmToAmps Scale="0.404089" />
             <MaxCurrent Unit="A" Value="1.340" />
          </Drive>
@@ -33,13 +33,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="66.1830499009" Scale="-28.5908792657" />
+            <VoltsToPosSI Offset="68.330947" Scale="-28.5893250062" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="2" AxisID="2" BoardID="6" Type="Prismatic">
          <Drive>
-            <AmpsToBits Offset="32755" Scale="5242.88" />
-            <BitsToFeedbackAmps Offset="-6.248872" Scale="0.000190738" />
+            <AmpsToBits Offset="32754" Scale="5242.88" />
+            <BitsToFeedbackAmps Offset="-6.249361" Scale="0.000190738" />
             <NmToAmps Scale="0.067828" />
             <MaxCurrent Unit="A" Value="0.670" />
          </Drive>
@@ -51,13 +51,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="-14.2351618179" Scale="59.1094099959" />
+            <VoltsToPosSI Offset="-14.393006" Scale="59.0904026245" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="3" AxisID="3" BoardID="6" Type="Revolute">
          <Drive>
             <AmpsToBits Offset="32788" Scale="-5242.88" />
-            <BitsToFeedbackAmps Offset="6.258244" Scale="-0.000190738" />
+            <BitsToFeedbackAmps Offset="6.258335" Scale="-0.000190738" />
             <NmToAmps Scale="1.949705" />
             <MaxCurrent Unit="A" Value="0.670" />
          </Drive>
@@ -69,13 +69,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="178.43181122" Scale="-78.505554412" />
+            <VoltsToPosSI Offset="178.625503426" Scale="-78.4873077482" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="4" AxisID="0" BoardID="7" Type="Revolute">
          <Drive>
             <AmpsToBits Offset="32992" Scale="-5242.88" />
-            <BitsToFeedbackAmps Offset="6.276145" Scale="-0.000190738" />
+            <BitsToFeedbackAmps Offset="6.276315" Scale="-0.000190738" />
             <NmToAmps Scale="1.949705" />
             <MaxCurrent Unit="A" Value="0.670" />
          </Drive>
@@ -87,13 +87,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="175.016737977" Scale="-77.2892981945" />
+            <VoltsToPosSI Offset="174.999097344" Scale="-77.2783514547" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="5" AxisID="1" BoardID="7" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32874" Scale="5242.88" />
-            <BitsToFeedbackAmps Offset="-6.246070" Scale="0.000190738" />
+            <AmpsToBits Offset="32871" Scale="5242.88" />
+            <BitsToFeedbackAmps Offset="-6.245965" Scale="0.000190738" />
             <NmToAmps Scale="1.949705" />
             <MaxCurrent Unit="A" Value="0.670" />
          </Drive>
@@ -105,13 +105,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="174.965299803" Scale="-76.8692395279" />
+            <VoltsToPosSI Offset="174.936545248" Scale="-76.8572250958" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="6" AxisID="2" BoardID="7" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32929" Scale="5242.88" />
-            <BitsToFeedbackAmps Offset="-6.267562" Scale="0.000190738" />
+            <AmpsToBits Offset="32927" Scale="5242.88" />
+            <BitsToFeedbackAmps Offset="-6.267308" Scale="0.000190738" />
             <NmToAmps Scale="1.949705" />
             <MaxCurrent Unit="A" Value="0.670" />
          </Drive>
@@ -123,10 +123,18 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="174.912352387" Scale="-77.5459477435" />
+            <VoltsToPosSI Offset="175.000983007" Scale="-77.5405711816" />
          </AnalogIn>
       </Actuator>
-      <Potentiometers Position="Actuators" />
+      <Potentiometers Position="Actuators">
+         <Tolerance Axis="0" Distance="5.00" Latency="0.01" Unit="deg" />
+         <Tolerance Axis="1" Distance="5.00" Latency="0.01" Unit="deg" />
+         <Tolerance Axis="2" Distance="5.00" Latency="0.01" Unit="mm" />
+         <Tolerance Axis="3" Distance="5.00" Latency="0.01" Unit="deg" />
+         <Tolerance Axis="4" Distance="25.00" Latency="0.01" Unit="deg" />
+         <Tolerance Axis="5" Distance="25.00" Latency="0.01" Unit="deg" />
+         <Tolerance Axis="6" Distance="25.00" Latency="0.01" Unit="deg" />
+      </Potentiometers>
    </Robot>
    <DigitalIn BitID="0" BoardID="6" Debounce="0.2" Name="PSM1-SUJClutch" Pressed="1" Trigger="all" />
    <DigitalIn BitID="2" BoardID="6" Debounce="0.2" Name="PSM1-ManipClutch" Pressed="1" Trigger="all" />

--- a/share/cuhk-daVinci/sawRobotIO1394-PSM2-33281.xml
+++ b/share/cuhk-daVinci/sawRobotIO1394-PSM2-33281.xml
@@ -2,8 +2,8 @@
    <Robot Name="PSM2" NumOfActuator="7" NumOfJoint="7" SN="33281">
       <Actuator ActuatorID="0" AxisID="0" BoardID="8" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32862" Scale="-5242.88" />
-            <BitsToFeedbackAmps Offset="6.244482" Scale="-0.000190738" />
+            <AmpsToBits Offset="32859" Scale="-5242.88" />
+            <BitsToFeedbackAmps Offset="6.244105" Scale="-0.000190738" />
             <NmToAmps Scale="0.404089" />
             <MaxCurrent Unit="A" Value="1.340" />
          </Drive>
@@ -15,13 +15,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="97.7967583154" Scale="-43.7082227782" />
+            <VoltsToPosSI Offset="99.127428" Scale="-43.7032818933" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="1" AxisID="1" BoardID="8" Type="Revolute">
          <Drive>
             <AmpsToBits Offset="32838" Scale="-5242.88" />
-            <BitsToFeedbackAmps Offset="6.244661" Scale="-0.000190738" />
+            <BitsToFeedbackAmps Offset="6.244523" Scale="-0.000190738" />
             <NmToAmps Scale="0.404089" />
             <MaxCurrent Unit="A" Value="1.340" />
          </Drive>
@@ -33,13 +33,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="65.5250623404" Scale="-28.7345487105" />
+            <VoltsToPosSI Offset="67.047521" Scale="-28.7299154525" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="2" AxisID="2" BoardID="8" Type="Prismatic">
          <Drive>
-            <AmpsToBits Offset="32912" Scale="5242.88" />
-            <BitsToFeedbackAmps Offset="-6.255722" Scale="0.000190738" />
+            <AmpsToBits Offset="32914" Scale="5242.88" />
+            <BitsToFeedbackAmps Offset="-6.255736" Scale="0.000190738" />
             <NmToAmps Scale="0.067828" />
             <MaxCurrent Unit="A" Value="0.670" />
          </Drive>
@@ -51,13 +51,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="-12.3809713272" Scale="59.2295770213" />
+            <VoltsToPosSI Offset="-12.515005" Scale="59.2205640507" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="3" AxisID="3" BoardID="8" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32874" Scale="-5242.88" />
-            <BitsToFeedbackAmps Offset="6.234964" Scale="-0.000190738" />
+            <AmpsToBits Offset="32873" Scale="-5242.88" />
+            <BitsToFeedbackAmps Offset="6.234956" Scale="-0.000190738" />
             <NmToAmps Scale="1.949705" />
             <MaxCurrent Unit="A" Value="0.670" />
          </Drive>
@@ -69,13 +69,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="177.601361826" Scale="-78.3186774216" />
+            <VoltsToPosSI Offset="177.708234648" Scale="-78.3233382834" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="4" AxisID="0" BoardID="9" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32803" Scale="-5242.88" />
-            <BitsToFeedbackAmps Offset="6.247450" Scale="-0.000190738" />
+            <AmpsToBits Offset="32804" Scale="-5242.88" />
+            <BitsToFeedbackAmps Offset="6.247554" Scale="-0.000190738" />
             <NmToAmps Scale="1.949705" />
             <MaxCurrent Unit="A" Value="0.670" />
          </Drive>
@@ -87,13 +87,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="177.495266104" Scale="-78.3190325185" />
+            <VoltsToPosSI Offset="177.652662291" Scale="-78.3076440325" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="5" AxisID="1" BoardID="9" Type="Revolute">
          <Drive>
-            <AmpsToBits Offset="32814" Scale="5242.88" />
-            <BitsToFeedbackAmps Offset="-6.245158" Scale="0.000190738" />
+            <AmpsToBits Offset="32815" Scale="5242.88" />
+            <BitsToFeedbackAmps Offset="-6.245154" Scale="0.000190738" />
             <NmToAmps Scale="1.949705" />
             <MaxCurrent Unit="A" Value="0.670" />
          </Drive>
@@ -105,13 +105,13 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="175.418658329" Scale="-78.1814079969" />
+            <VoltsToPosSI Offset="175.408201713" Scale="-78.1802560517" />
          </AnalogIn>
       </Actuator>
       <Actuator ActuatorID="6" AxisID="2" BoardID="9" Type="Revolute">
          <Drive>
             <AmpsToBits Offset="32763" Scale="5242.88" />
-            <BitsToFeedbackAmps Offset="-6.253929" Scale="0.000190738" />
+            <BitsToFeedbackAmps Offset="-6.253904" Scale="0.000190738" />
             <NmToAmps Scale="1.949705" />
             <MaxCurrent Unit="A" Value="0.670" />
          </Drive>
@@ -123,10 +123,18 @@
          </Encoder>
          <AnalogIn>
             <BitsToVolts Offset="0" Scale="6.86646e-05" />
-            <VoltsToPosSI Offset="179.264182577" Scale="-78.4676801996" />
+            <VoltsToPosSI Offset="179.237257916" Scale="-78.4867059661" />
          </AnalogIn>
       </Actuator>
-      <Potentiometers Position="Actuators" />
+      <Potentiometers Position="Actuators">
+         <Tolerance Axis="0" Distance="5.00" Latency="0.01" Unit="deg" />
+         <Tolerance Axis="1" Distance="5.00" Latency="0.01" Unit="deg" />
+         <Tolerance Axis="2" Distance="5.00" Latency="0.01" Unit="mm" />
+         <Tolerance Axis="3" Distance="5.00" Latency="0.01" Unit="deg" />
+         <Tolerance Axis="4" Distance="5.00" Latency="0.01" Unit="deg" />
+         <Tolerance Axis="5" Distance="5.00" Latency="0.01" Unit="deg" />
+         <Tolerance Axis="6" Distance="5.00" Latency="0.01" Unit="deg" />
+      </Potentiometers>
    </Robot>
    <DigitalIn BitID="0" BoardID="8" Debounce="0.2" Name="PSM2-SUJClutch" Pressed="1" Trigger="all" />
    <DigitalIn BitID="2" BoardID="8" Debounce="0.2" Name="PSM2-ManipClutch" Pressed="1" Trigger="all" />


### PR DESCRIPTION
Hi Anton,

We finished calibration for v1.5. As I said in my email, we have to enlarge some pot tolerance for both PSM1 and PSM2. Another issue is we don't have the original cal file for our ECM. So I simply copied cal file from jhu-daVinci. Some parameters should be different, but I cannot find a better solution. Could you advise how to do ECM calibration without the cal file? Thanks!

Best regards,
Zerui