### PR TITLE
use default initializers for member variables

### DIFF
--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -11,7 +11,9 @@
 
 project (sawIntuitiveResearchKit)
 
-cmake_minimum_required (VERSION 2.8)
+set (CMAKE_CXX_STANDARD 14)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
+set (CMAKE_CXX_EXTENSIONS OFF)
 
 set (REQUIRED_CISST_LIBRARIES
      cisstCommon

--- a/components/code/mtsIntuitiveResearchKitPSM.cpp
+++ b/components/code/mtsIntuitiveResearchKitPSM.cpp
@@ -54,14 +54,6 @@ void mtsIntuitiveResearchKitPSM::Init(void)
 {
     // main initialization from base type
     mtsIntuitiveResearchKitArm::Init();
-    mSnakeLike = false;
-
-    mSnakeLike = false;
-    ManipulatorPSMSnake = 0;
-    ToolOffset = 0;
-
-    mAdapterNeedEngage = false;
-    mToolNeedEngage = false;
 
     // state machine specific to PSM, see base class for other states
     mArmState.AddState("CHANGING_COUPLING_ADAPTER");
@@ -118,9 +110,6 @@ void mtsIntuitiveResearchKitPSM::Init(void)
     mArmState.SetEnterCallback("MANUAL",
                                &mtsIntuitiveResearchKitPSM::EnterManual,
                                this);
-
-    // kinematics
-    mSnakeLike = false;
 
     // initialize trajectory data
     mJointTrajectory.Velocity.Ref(2, 0).SetAll(180.0 * cmnPI_180); // degrees per second

--- a/components/include/sawIntuitiveResearchKit/mtsIntuitiveResearchKitPSM.h
+++ b/components/include/sawIntuitiveResearchKit/mtsIntuitiveResearchKitPSM.h
@@ -151,10 +151,10 @@ protected:
     } ClutchEvents;
 
     /*! 5mm tools with 8 joints */
-    bool mSnakeLike;
+    bool mSnakeLike = false;
 
-    robManipulatorPSMSnake * ManipulatorPSMSnake;
-    robManipulator * ToolOffset;
+    robManipulatorPSMSnake * ManipulatorPSMSnake = nullptr;
+    robManipulator * ToolOffset = nullptr;
     vctFrm4x4 ToolOffsetTransformation;
 
     prmStateJoint Jaw, JawDesired;
@@ -165,8 +165,8 @@ protected:
     unsigned int EngagingStage; // 0 requested
     unsigned int LastEngagingStage;
 
-    bool mAdapterNeedEngage;
-    bool mToolNeedEngage;
+    bool mAdapterNeedEngage = false;
+    bool mToolNeedEngage = false;
 
     struct {
         bool Started;


### PR DESCRIPTION
It needs this patch https://github.com/jhu-dvrk/dvrk-ros/pull/27 to be accepted in advance.