### PR TITLE
Set current state to "ENABLED" only if desired state is "ENABLED" 

### DIFF
--- a/components/code/mtsTeleOperationPSM.cpp
+++ b/components/code/mtsTeleOperationPSM.cpp
@@ -618,7 +618,9 @@ void mtsTeleOperationPSM::TransitionAligningMTM(void)
     // finally check for transition
     if ((orientationErrorInDegrees <= mtsIntuitiveResearchKit::TeleOperationPSMOrientationTolerance)
         && (mGripperJawTransitions > 1)) {
-        mTeleopState.SetCurrentState("ENABLED");
+        if (mTeleopState.DesiredState() == "ENABLED") {
+            mTeleopState.SetCurrentState("ENABLED");
+        }
     } else {
         // check timer and issue a message
         if ((StateTable.GetTic() - mInStateTimer) > 2.0 * cmn_s) {


### PR DESCRIPTION
If mIgnoreJaw is true, mTeleopState.SetCurrentState("ENABLED") will be called when "stop" button is pressed after tele operation starts.  It is unexpected.  This fix can handle different "desired state" by setting the current state to "ENABLED" only if the desired state is "ENABLED".

reference
https://github.com/jhu-dvrk/sawIntuitiveResearchKit/pull/113