### PR TITLE
Update teleop scale in console GUI

### DIFF
--- a/components/code/mtsIntuitiveResearchKitConsole.cpp
+++ b/components/code/mtsIntuitiveResearchKitConsole.cpp
@@ -1440,6 +1440,7 @@ bool mtsIntuitiveResearchKitConsole::AddTeleopPSMInterfaces(TeleopPSM * teleop)
         teleop->InterfaceRequired->AddEventHandlerWrite(&mtsIntuitiveResearchKitConsole::ErrorEventHandler, this, "error");
         teleop->InterfaceRequired->AddEventHandlerWrite(&mtsIntuitiveResearchKitConsole::WarningEventHandler, this, "warning");
         teleop->InterfaceRequired->AddEventHandlerWrite(&mtsIntuitiveResearchKitConsole::StatusEventHandler, this, "status");
+        teleop->InterfaceRequired->AddEventHandlerWrite(&mtsIntuitiveResearchKitConsole::TeleopScaleChangedEventHandler, this, "scale");
     } else {
         CMN_LOG_CLASS_INIT_ERROR << "AddTeleopPSMInterfaces: failed to add Main interface for teleop \""
                                  << teleop->Name() << "\"" << std::endl;
@@ -2711,6 +2712,11 @@ void mtsIntuitiveResearchKitConsole::OperatorPresentEventHandler(const prmEventB
     }
     UpdateTeleopState();
     console_events.operator_present(button);
+}
+
+void mtsIntuitiveResearchKitConsole::TeleopScaleChangedEventHandler(const double & scale)
+{
+    ConfigurationEvents.scale(scale);
 }
 
 void mtsIntuitiveResearchKitConsole::ErrorEventHandler(const mtsMessage & message)

--- a/components/include/sawIntuitiveResearchKit/mtsIntuitiveResearchKitConsole.h
+++ b/components/include/sawIntuitiveResearchKit/mtsIntuitiveResearchKitConsole.h
@@ -349,6 +349,7 @@ class CISST_EXPORT mtsIntuitiveResearchKitConsole: public mtsTaskFromSignal
     void ClutchEventHandler(const prmEventButton & button);
     void CameraEventHandler(const prmEventButton & button);
     void OperatorPresentEventHandler(const prmEventButton & button);
+    void TeleopScaleChangedEventHandler(const double & scale);
 
     bool m_calibration_mode = false;
 


### PR DESCRIPTION
Currently, if a PSM teleop scale is set in the console configuration file, the console GUI will show 0.2 instead of the actual teleop scale factor being used. This will make sure the console responds to PSM teleop scale-change events, so the actual teleop scale and the scale displayed in the GUI will stay in sync.
