### PR TITLE
Feed Forward Issue Temporary Fix

### DIFF
--- a/core/components/code/mtsIntuitiveResearchKitArm.cpp
+++ b/core/components/code/mtsIntuitiveResearchKitArm.cpp
@@ -1531,6 +1531,8 @@ void mtsIntuitiveResearchKitArm::control_move_jp(void)
 
 void mtsIntuitiveResearchKitArm::control_servo_cp(void)
 {
+    // std::cerr << "-";
+    
     if (m_pid_new_goal) {
         // copy current position
         vctDoubleVec jp(m_kin_measured_js.Position());
@@ -1946,6 +1948,7 @@ void mtsIntuitiveResearchKitArm::servo_jp_internal(const vctDoubleVec & jp,
         update_feed_forward(m_pid_feed_forward_servo_jf.ForceTorque());
 
     }
+    // std::cerr << "---- Arm" << m_pid_feed_forward_servo_jf << std::endl;
     PID.feed_forward_jf(m_pid_feed_forward_servo_jf);
 
     // assign positions and check limits

--- a/core/components/code/mtsIntuitiveResearchKitArm.cpp
+++ b/core/components/code/mtsIntuitiveResearchKitArm.cpp
@@ -1531,8 +1531,6 @@ void mtsIntuitiveResearchKitArm::control_move_jp(void)
 
 void mtsIntuitiveResearchKitArm::control_servo_cp(void)
 {
-    // std::cerr << "-";
-    
     if (m_pid_new_goal) {
         // copy current position
         vctDoubleVec jp(m_kin_measured_js.Position());
@@ -1948,7 +1946,6 @@ void mtsIntuitiveResearchKitArm::servo_jp_internal(const vctDoubleVec & jp,
         update_feed_forward(m_pid_feed_forward_servo_jf.ForceTorque());
 
     }
-    // std::cerr << "---- Arm" << m_pid_feed_forward_servo_jf << std::endl;
     PID.feed_forward_jf(m_pid_feed_forward_servo_jf);
 
     // assign positions and check limits

--- a/core/components/code/mtsIntuitiveResearchKitPSM.cpp
+++ b/core/components/code/mtsIntuitiveResearchKitPSM.cpp
@@ -1212,6 +1212,12 @@ void mtsIntuitiveResearchKitPSM::servo_jp_internal(const vctDoubleVec & jp,
         mtsIntuitiveResearchKitArm::servo_jp_internal(jp, jv);
         return;
     }
+
+    if (use_feed_forward()) {
+        update_feed_forward(m_pid_feed_forward_servo_jf.ForceTorque());
+    }
+    PID.feed_forward_jf(m_pid_feed_forward_servo_jf);
+
     CMN_ASSERT(m_servo_jp_param.Goal().size() == 7);
     // first 6 joints, assign positions and check limits
     vctDoubleVec jp_clipped(jp);


### PR DESCRIPTION
Problem: The feed forward feature does not work on the PSM arms.

Temporary Fix:
Add feed forward code into the mtsIntutiveResearchKitPSM.cpp
Make sure you are under servo_jp mode, then the PID feed forward feature would work as expected

This is only a temporary fix, a further clean and consistent solution is still required.