### PR TITLE
Fix jaw movement

### DIFF
--- a/core/components/code/mtsIntuitiveResearchKitArm.cpp
+++ b/core/components/code/mtsIntuitiveResearchKitArm.cpp
@@ -1986,7 +1986,7 @@ void mtsIntuitiveResearchKitArm::hold(void)
     SetControlSpaceAndMode(mtsIntuitiveResearchKitArmTypes::JOINT_SPACE,
                            mtsIntuitiveResearchKitArmTypes::POSITION_MODE);
     // set goal
-    m_servo_jp.Assign(m_kin_setpoint_js.Position(), number_of_joints_kinematics());
+    m_servo_jp.Assign(m_kin_setpoint_js.Position(), number_of_joints());
     m_pid_new_goal = true;
 }
 

--- a/core/components/code/mtsIntuitiveResearchKitArm.cpp
+++ b/core/components/code/mtsIntuitiveResearchKitArm.cpp
@@ -1511,7 +1511,7 @@ void mtsIntuitiveResearchKitArm::control_move_jp(void)
                                       m_servo_jv,
                                       m_trajectory_j.goal,
                                       m_trajectory_j.goal_v);
-    mtsIntuitiveResearchKitArm::servo_jp_internal(m_servo_jp, m_servo_jv);
+    servo_jp_internal(m_servo_jp, m_servo_jv);
 
     const robReflexxes::ResultType trajectoryResult = m_trajectory_j.Reflexxes.ResultValue();
     const double currentTime = this->StateTable.GetTic();

--- a/core/components/code/mtsIntuitiveResearchKitPSM.cpp
+++ b/core/components/code/mtsIntuitiveResearchKitPSM.cpp
@@ -1289,6 +1289,7 @@ void mtsIntuitiveResearchKitPSM::jaw_servo_jp(const prmPositionJointSet & jawPos
 
     // save goal
     m_jaw_servo_jp = jawPosition.Goal().at(0);
+    m_servo_jp.at(6) = m_jaw_servo_jp;
     m_pid_new_goal = true;
 }
 

--- a/core/components/code/mtsIntuitiveResearchKitPSM.cpp
+++ b/core/components/code/mtsIntuitiveResearchKitPSM.cpp
@@ -1248,6 +1248,17 @@ void mtsIntuitiveResearchKitPSM::LeaveManual(void)
     hold();
 }
 
+double mtsIntuitiveResearchKitPSM::clip_jaw_jp(double jp)
+{
+    if (jp > m_jaw_configuration_js.PositionMax().at(0)) {
+        jp = m_jaw_configuration_js.PositionMax().at(0);
+    } else if (jp < m_jaw_configuration_js.PositionMin().at(0)) {
+        jp = m_jaw_configuration_js.PositionMin().at(0);
+    }
+
+    return jp;
+}
+
 void mtsIntuitiveResearchKitPSM::jaw_servo_jp(const prmPositionJointSet & jawPosition)
 {
     // we need to need to at least ready to control in cartesian space
@@ -1325,9 +1336,14 @@ void mtsIntuitiveResearchKitPSM::servo_jp_internal(const vctDoubleVec & jp,
 
     CMN_ASSERT(m_servo_jp_param.Goal().size() == 7);
     // first 6 joints, assign positions and check limits
-    vctDoubleVec jp_clipped(jp);
+    vctDoubleVec jp_clipped(jp.Ref(number_of_joints_kinematics()));
     clip_jp(jp_clipped);
     ToJointsPID(jp_clipped, m_servo_jp_param.Goal());
+
+    if (jp.size() == 7) {
+        m_jaw_servo_jp = clip_jaw_jp(jp.at(6));
+    }
+
     // velocity - current code only support jaw_servo_jv if servo_jp has a velocity goal
     const size_t jv_size = jv.size();
     m_servo_jp_param.Velocity().SetSize(7);

--- a/core/components/include/sawIntuitiveResearchKit/mtsIntuitiveResearchKitPSM.h
+++ b/core/components/include/sawIntuitiveResearchKit/mtsIntuitiveResearchKitPSM.h
@@ -140,6 +140,7 @@ class CISST_EXPORT mtsIntuitiveResearchKitPSM: public mtsIntuitiveResearchKitArm
     void EventHandlerManipClutch(const prmEventButton & button);
     void EventHandlerSUJClutch(const prmEventButton & button);
 
+    double clip_jaw_jp(const double jp);
     void jaw_servo_jp(const prmPositionJointSet & jp);
     void jaw_move_jp(const prmPositionJointSet & jp);
     void jaw_servo_jf(const prmForceTorqueJointSet & jf);


### PR DESCRIPTION
`control_move_jp` was using the base class version of `servo_jp_internal`, so joint limits for the jaw were being set to garbage values in `clip_jp`. Now we use the correct derived version of `servo_jp_internal`, and since `m_servo_jp` already included non-kinematic joints this works fine. These changes effectively make `m_jaw_servo_jp` redundant (since `m_servo_jp[6]` has the same data), but I'm keeping it for now.

Should resolve issue #215 