### PR TITLE
camera_roll_offset for ECMs

### DIFF
--- a/core/components/code/mtsTeleOperationECM.cpp
+++ b/core/components/code/mtsTeleOperationECM.cpp
@@ -99,6 +99,7 @@ void mtsTeleOperationECM::Init(void)
     mConfigurationStateTable->SetAutomaticAdvance(false);
     AddStateTable(mConfigurationStateTable);
     mConfigurationStateTable->AddData(m_config.scale, "scale");
+    mConfigurationStateTable->AddData(m_config.camera_roll_offset, "camera_roll_offset");
 
     mtsInterfaceRequired * interfaceRequired = AddInterfaceRequired("MTML");
     if (interfaceRequired) {
@@ -638,8 +639,8 @@ void mtsTeleOperationECM::RunEnabled(void)
         }
     }
 
-    // adjusting movement for camera orientation
-    double totalChangeJoint3 = changeDir[3] + mInitial.ECMPositionJoint[3];
+    // adjusting movement for camera orientation (plus offset on camera roll if present between ECM and endoscope)
+    double totalChangeJoint3 = changeDir[3] + mInitial.ECMPositionJoint[3] + m_config.camera_roll_offset;
     changeJoints[0] = changeDir[0] * cos(totalChangeJoint3) - changeDir[1] * sin(totalChangeJoint3);
     changeJoints[1] = changeDir[1] * cos(totalChangeJoint3) + changeDir[0] * sin(totalChangeJoint3);
     changeJoints[2] = changeDir[2];

--- a/core/components/code/teleop_ECM_configuration.cdg
+++ b/core/components/code/teleop_ECM_configuration.cdg
@@ -17,4 +17,10 @@ class {
         visibility public;
         default mtsIntuitiveResearchKit::TeleOperationECM::Scale;
     }
+    member {
+        name camera_roll_offset; //configure_parameter via *TeleOp.json & also to be manually added as offset to 4th joint on kinematic/ECM.json to update Tfs
+        type double;
+        visibility public;
+        default 0.0;
+    }
 }


### PR DESCRIPTION
mtsTeleOperationECM.cpp;teleop_ECM_configuration.cdg: added functionality to add offset between ECM and endoscope on roll. Tested on 2.4.0, 22.04, humble.