### PR TITLE
Add MTM base-frame x-offset option to system config wizard

### DIFF
--- a/core/applications/system-config-wizard/TODO.md
+++ b/core/applications/system-config-wizard/TODO.md
@@ -11,7 +11,6 @@
 - [ ] Status/tool tips
 - [ ] Make more keyboard friendly/better accessibility
 - [ ] Move edit/delete buttons to base ItemView?
-- [ ] Replace temporary in-line style sheets with custom QStyle
 - [ ] Help buttons e.g. on dialogs
 - [ ] Icons? e.g. delete, edit, add item
 - [ ] Make prettier
@@ -62,7 +61,7 @@
 - [x] File dialogs install *.json filter
 - [x] Mark unsaved when console input config changes
 - [ ] Chatty/path/audio volume config
-- [ ] Intro view when no config is open
+- [ ] Intro/help view when no config is open
 
 ### Config item editors
 

--- a/core/applications/system-config-wizard/include/arm_editor.hpp
+++ b/core/applications/system-config-wizard/include/arm_editor.hpp
@@ -200,6 +200,8 @@ public:
     bool isComplete() const override;
 
 private:
+    static constexpr int default_MTM_x_offset = 180;
+
     ArmConfig* config;
     SystemConfigModel* system_model;
 
@@ -208,6 +210,7 @@ private:
     QSpinBox* ecm_mounting_pitch;
     QSpinBox* hrsv_pitch;
     QComboBox* suj_list;
+    QSpinBox* mtm_offset;
 
     bool block_suj_updates;
 


### PR DESCRIPTION
Addresses issue discovered in #242 where both left/right MTM base frames are generated with the same position, causing issues with ECM teleoperation.
