### PR TITLE
Refactoring of the simulation mode using CISST prmSimulationType

### DIFF
--- a/core/components/code/arm_proxy.cpp
+++ b/core/components/code/arm_proxy.cpp
@@ -163,7 +163,7 @@ void dvrk::arm_proxy::create_arm(void)
         {
             mtsIntuitiveResearchKitSUJ * suj = new mtsIntuitiveResearchKitSUJ(m_name, m_config->period);
             if (m_config->simulation == dvrk::simulation::SIMULATION_KINEMATIC) {
-                suj->set_simulated();
+                suj->SetSimulationMode(prmSimulationType::SimulationType::KINEMATIC);
             } else if (m_config->simulation == dvrk::simulation::SIMULATION_NONE) {
                 m_system->m_connections.Add(m_name, "no_mux_reset",
                                             m_IO_component_name, "no_mux_reset");
@@ -195,7 +195,7 @@ void dvrk::arm_proxy::create_arm(void)
 #if sawIntuitiveResearchKit_HAS_SUJ_Si
             mtsIntuitiveResearchKitSUJSi * suj = new mtsIntuitiveResearchKitSUJSi(m_name, m_config->period);
             if (m_config->simulation == dvrk::simulation::SIMULATION_KINEMATIC) {
-                suj->set_simulated();
+                suj->SetSimulationMode(prmSimulationType::SimulationType::KINEMATIC);
             }
             suj->Configure(m_arm_configuration_file);
             component_manager->AddComponent(suj);
@@ -292,7 +292,7 @@ void dvrk::arm_proxy::create_arm(void)
         && !m_config->SUJ()) {
         CMN_ASSERT(m_arm != nullptr);
         if (m_config->simulation == dvrk::simulation::SIMULATION_KINEMATIC) {
-            m_arm->set_simulated();
+            m_arm->SetSimulationMode(prmSimulationType::SimulationType::KINEMATIC);
         }
         m_arm->set_calibration_mode(m_calibration_mode);
         m_arm->Configure(m_arm_configuration_file);
@@ -444,7 +444,7 @@ void dvrk::arm_proxy::create_PID(void)
     bool hasIO = true;
     pid->Configure(m_PID_configuration_file);
     if (m_config->simulation == dvrk::simulation::SIMULATION_KINEMATIC) {
-        pid->SetSimulated();
+        pid->SetSimulationMode(prmSimulationType::SimulationType::KINEMATIC);
         hasIO = false;
     }
     component_manager->AddComponent(pid);

--- a/core/components/code/mtsIntuitiveResearchKitArm.cpp
+++ b/core/components/code/mtsIntuitiveResearchKitArm.cpp
@@ -857,9 +857,11 @@ void mtsIntuitiveResearchKitArm::Cleanup(void)
     CMN_LOG_CLASS_INIT_VERBOSE << GetName() << ": Cleanup" << std::endl;
 }
 
-void mtsIntuitiveResearchKitArm::set_simulated(void)
+void mtsIntuitiveResearchKitArm::SetSimulationMode(const prmSimulationType::SimulationType& mode)
 {
-    m_simulated = true;
+    // forward to the base class
+    prmSimulationType::SetSimulationMode(mode);
+    
     // in simulation mode, we don't need IO
     RemoveInterfaceRequired("RobotIO");
 }
@@ -867,7 +869,7 @@ void mtsIntuitiveResearchKitArm::set_simulated(void)
 void mtsIntuitiveResearchKitArm::get_robot_data(void)
 {
     // check that the robot still has power
-    if (m_powered && !m_simulated) {
+    if (m_powered && !(GetSimulationMode() == prmSimulationType::KINEMATIC)) {
         vctBoolVec actuatorAmplifiersStatus(number_of_joints());
         IO.GetActuatorAmpStatus(actuatorAmplifiersStatus);
         vctBoolVec brakeAmplifiersStatus(number_of_brakes());
@@ -1198,7 +1200,7 @@ void mtsIntuitiveResearchKitArm::EnterPowering(void)
 
     m_powered = false;
 
-    if (m_simulated) {
+    if ((GetSimulationMode() == prmSimulationType::KINEMATIC)) {
         PID.enable_measured_setpoint_check(false);
         PID.enable(true);
         PID.enable_joints(vctBoolVec(number_of_joints(), true));
@@ -1227,7 +1229,7 @@ void mtsIntuitiveResearchKitArm::EnterPowering(void)
 
 void mtsIntuitiveResearchKitArm::TransitionPowering(void)
 {
-    if (m_simulated) {
+    if ((GetSimulationMode() == prmSimulationType::KINEMATIC)) {
         mArmState.SetCurrentState("ENABLED");
         return;
     }
@@ -1256,7 +1258,7 @@ void mtsIntuitiveResearchKitArm::EnterEnabled(void)
 {
     UpdateOperatingStateAndBusy(prmOperatingState::ENABLED, false);
 
-    if (m_simulated) {
+    if ((GetSimulationMode() == prmSimulationType::KINEMATIC)) {
         m_powered = true;
         return;
     }
@@ -1292,7 +1294,7 @@ void mtsIntuitiveResearchKitArm::EnterCalibratingEncodersFromPots(void)
     UpdateOperatingStateAndBusy(prmOperatingState::ENABLED, true);
 
     // if simulated, no need to bias encoders
-    if (m_simulated) {
+    if ((GetSimulationMode() == prmSimulationType::KINEMATIC)) {
         m_arm_interface->SendStatus(this->GetName() + ": simulated mode, no need to calibrate encoders");
         return;
     }
@@ -1322,7 +1324,7 @@ void mtsIntuitiveResearchKitArm::EnterCalibratingEncodersFromPots(void)
 
 void mtsIntuitiveResearchKitArm::TransitionCalibratingEncodersFromPots(void)
 {
-    if (m_simulated || m_encoders_biased_from_pots) {
+    if ((GetSimulationMode() == prmSimulationType::KINEMATIC) || m_encoders_biased_from_pots) {
         m_encoders_biased_from_pots = true;
         mArmState.SetCurrentState("ENCODERS_BIASED");
         return;
@@ -1370,7 +1372,7 @@ void mtsIntuitiveResearchKitArm::EnterHoming(void)
     PID.enable_measured_setpoint_check(true);
 
     // release brakes if any
-    if ((has_brakes()) && !m_simulated) {
+    if ((has_brakes()) && !(GetSimulationMode() == prmSimulationType::KINEMATIC)) {
         IO.BrakeRelease();
     }
 
@@ -1456,7 +1458,7 @@ void mtsIntuitiveResearchKitArm::EnterHomed(void)
     SetControlSpaceAndMode(mtsIntuitiveResearchKitControlTypes::UNDEFINED_SPACE,
                            mtsIntuitiveResearchKitControlTypes::UNDEFINED_MODE);
 
-    if (m_simulated) {
+    if ((GetSimulationMode() == prmSimulationType::KINEMATIC)) {
         return;
     }
 

--- a/core/components/code/mtsIntuitiveResearchKitECM.cpp
+++ b/core/components/code/mtsIntuitiveResearchKitECM.cpp
@@ -119,9 +119,11 @@ mtsIntuitiveResearchKitECM::mtsIntuitiveResearchKitECM(const mtsTaskPeriodicCons
 // need to define destructor after definition of GravityCompensationECM is available
 mtsIntuitiveResearchKitECM::~mtsIntuitiveResearchKitECM() = default;
 
-void mtsIntuitiveResearchKitECM::set_simulated(void)
+void mtsIntuitiveResearchKitECM::SetSimulationMode(const prmSimulationType::SimulationType& mode)
 {
-    mtsIntuitiveResearchKitArm::set_simulated();
+    // forward the simulation mode setup to the base class
+    mtsIntuitiveResearchKitArm::SetSimulationMode(mode);
+    
     // in simulation mode, we don't need clutch IO
     RemoveInterfaceRequired("arm_clutch");
     // for Si systems, remove a few more interfaces
@@ -137,7 +139,7 @@ void mtsIntuitiveResearchKitECM::set_generation(const dvrk::generation generatio
     mtsIntuitiveResearchKitArm::set_generation(generation);
     // for S/si, add SUJClutch interface
     if ((generation == dvrk::generation::Si)
-        && !m_simulated) {
+        && !(GetSimulationMode() == prmSimulationType::KINEMATIC)) {
         auto interfaceRequired = AddInterfaceRequired("SUJ_clutch");
         if (interfaceRequired) {
             interfaceRequired->AddEventHandlerWrite(&mtsIntuitiveResearchKitECM::EventHandlerSUJClutch, this, "Button");
@@ -341,7 +343,7 @@ bool mtsIntuitiveResearchKitECM::is_cartesian_ready(void) const
 void mtsIntuitiveResearchKitECM::SetGoalHomingArm(void)
 {
     // if simulated, start at zero but insert endoscope so it can be used in cartesian mode
-    if (m_simulated) {
+    if (GetSimulationMode() == prmSimulationType::KINEMATIC) {
         m_trajectory_j.goal.SetAll(0.0);
         m_trajectory_j.goal.at(2) = 12.0 * cmn_cm;
         return;

--- a/core/components/code/mtsIntuitiveResearchKitMTM.cpp
+++ b/core/components/code/mtsIntuitiveResearchKitMTM.cpp
@@ -49,9 +49,11 @@ mtsIntuitiveResearchKitMTM::mtsIntuitiveResearchKitMTM(const mtsTaskPeriodicCons
 
 mtsIntuitiveResearchKitMTM::~mtsIntuitiveResearchKitMTM() = default;
 
-void mtsIntuitiveResearchKitMTM::set_simulated(void)
+void mtsIntuitiveResearchKitMTM::SetSimulationMode(const prmSimulationType::SimulationType &mode)
 {
-    mtsIntuitiveResearchKitArm::set_simulated();
+    // forward to base class implementation
+    mtsIntuitiveResearchKitArm::SetSimulationMode(mode);
+
     // in simulation mode, we don't need IO Gripper
     RemoveInterfaceRequired("GripperIO");
 }
@@ -332,7 +334,7 @@ bool mtsIntuitiveResearchKitMTM::is_cartesian_ready(void) const
 void mtsIntuitiveResearchKitMTM::SetGoalHomingArm(void)
 {
     // if simulated, start at zero but insert tool so it can be used in cartesian mode
-    if (m_simulated || m_homing_goes_to_zero) {
+    if ((GetSimulationMode() == prmSimulationType::KINEMATIC) || m_homing_goes_to_zero) {
         m_trajectory_j.goal.SetAll(0.0);
     } else {
         // stay at current position by default
@@ -352,8 +354,8 @@ void mtsIntuitiveResearchKitMTM::EnterCalibratingRoll(void)
     UpdateOperatingStateAndBusy(prmOperatingState::ENABLED, true);
 
     if (!m_calibration_mode) {
-        if (m_simulated || is_homed()) {
-            if (m_simulated) {
+        if ((GetSimulationMode() == prmSimulationType::KINEMATIC) || is_homed()) {
+            if ((GetSimulationMode() == prmSimulationType::KINEMATIC)) {
                 // all encoders are biased, including roll
                 m_encoders_biased = true;
             }
@@ -390,7 +392,7 @@ void mtsIntuitiveResearchKitMTM::EnterCalibratingRoll(void)
 void mtsIntuitiveResearchKitMTM::RunCalibratingRoll(void)
 {
     if (!m_calibration_mode) {
-        if (m_simulated || is_homed()) {
+        if ((GetSimulationMode() == prmSimulationType::KINEMATIC) || is_homed()) {
             mArmState.SetCurrentState("ROLL_CALIBRATED");
             return;
         }
@@ -460,7 +462,7 @@ void mtsIntuitiveResearchKitMTM::EnterResettingRollEncoder(void)
 {
     UpdateOperatingStateAndBusy(prmOperatingState::ENABLED, true);
 
-    if (m_simulated || is_homed()) {
+    if ((GetSimulationMode() == prmSimulationType::KINEMATIC) || is_homed()) {
         mArmState.SetCurrentState("HOMING");
         return;
     }
@@ -512,7 +514,7 @@ void mtsIntuitiveResearchKitMTM::get_robot_data(void)
 {
     mtsIntuitiveResearchKitArm::get_robot_data();
 
-    if (m_simulated) {
+    if ((GetSimulationMode() == prmSimulationType::KINEMATIC)) {
         return;
     }
 

--- a/core/components/include/sawIntuitiveResearchKit/mtsIntuitiveResearchKitArm.h
+++ b/core/components/include/sawIntuitiveResearchKit/mtsIntuitiveResearchKitArm.h
@@ -42,6 +42,8 @@ http://www.cisst.org/cisst/license.txt.
 #include <cisstParameterTypes/prmForwardKinematicsResponse.h>
 #include <cisstParameterTypes/prmStateCartesian.h>
 
+#include <cisstParameterTypes/prmSimulationType.h>
+
 #include <cisstRobot/robManipulator.h>
 #include <cisstRobot/robReflexxes.h>
 
@@ -57,7 +59,7 @@ class osaCartesianImpedanceController;
 // Always include last
 #include <sawIntuitiveResearchKit/sawIntuitiveResearchKitExport.h>
 
-class CISST_EXPORT mtsIntuitiveResearchKitArm: public mtsTaskPeriodic
+class CISST_EXPORT mtsIntuitiveResearchKitArm: public mtsTaskPeriodic, public prmSimulationType
 {
     CMN_DECLARE_SERVICES(CMN_NO_DYNAMIC_CREATION, CMN_LOG_ALLOW_DEFAULT);
 
@@ -71,10 +73,13 @@ class CISST_EXPORT mtsIntuitiveResearchKitArm: public mtsTaskPeriodic
     void Run(void) override;
     void Cleanup(void) override;
 
+    // Override from prmSimulationType for handling simulation mode in derived classes
+    virtual void SetSimulationMode(const prmSimulationType::SimulationType& mode) override;
+
     inline void crtk_version(std::string & placeholder) const {
         placeholder = mtsIntuitiveResearchKit::crtk_version;
     }
-    virtual void set_simulated(void);
+    // virtual void set_simulated(void);
     virtual inline void set_calibration_mode(const bool mode) {
         m_calibration_mode = mode;
     }
@@ -533,9 +538,6 @@ class CISST_EXPORT mtsIntuitiveResearchKitArm: public mtsTaskPeriodic
     // generation
     dvrk::generation m_generation
         = dvrk::generation::GENERATION_UNDEFINED;
-
-    // flag to determine if this is connected to actual IO/hardware or simulated
-    bool m_simulated = false;
 
     // flag to determine if the arm is running in calibration mode, i.e. turn off checks using potentiometers
     bool m_calibration_mode = false;

--- a/core/components/include/sawIntuitiveResearchKit/mtsIntuitiveResearchKitECM.h
+++ b/core/components/include/sawIntuitiveResearchKit/mtsIntuitiveResearchKitECM.h
@@ -40,7 +40,8 @@ class CISST_EXPORT mtsIntuitiveResearchKitECM: public mtsIntuitiveResearchKitArm
     mtsIntuitiveResearchKitECM(const mtsTaskPeriodicConstructorArg & arg);
     ~mtsIntuitiveResearchKitECM();
 
-    void set_simulated(void) override;
+    // This is overriding the method in prmSimulationType so we can implement simulation mode for MTM
+    void SetSimulationMode(const prmSimulationType::SimulationType& mode) override;
 
  protected:
     void set_generation(const dvrk::generation generation) override;

--- a/core/components/include/sawIntuitiveResearchKit/mtsIntuitiveResearchKitMTM.h
+++ b/core/components/include/sawIntuitiveResearchKit/mtsIntuitiveResearchKitMTM.h
@@ -38,10 +38,10 @@ public:
     mtsIntuitiveResearchKitMTM(const mtsTaskPeriodicConstructorArg & arg);
     ~mtsIntuitiveResearchKitMTM();
 
-    void set_simulated(void) override;
+    // This is overriding the method in prmSimulationType so we can implement simulation mode for MTM
+    void SetSimulationMode(const prmSimulationType::SimulationType& mode) override;
 
-protected:
-    enum JointName {
+    protected : enum JointName {
         JNT_OUTER_YAW = 0,
         JNT_OUTER_PITCH_1 = 1,
         JNT_OUTER_PITCH_2 = 2,

--- a/core/components/include/sawIntuitiveResearchKit/mtsIntuitiveResearchKitPSM.h
+++ b/core/components/include/sawIntuitiveResearchKit/mtsIntuitiveResearchKitPSM.h
@@ -41,9 +41,9 @@ class CISST_EXPORT mtsIntuitiveResearchKitPSM: public mtsIntuitiveResearchKitArm
     mtsIntuitiveResearchKitPSM(const mtsTaskPeriodicConstructorArg & arg);
     ~mtsIntuitiveResearchKitPSM();
 
-    void set_simulated(void) override;
+    void SetSimulationMode(const prmSimulationType::SimulationType &mode) override;
 
- protected:
+protected:
     void set_generation(const dvrk::generation generation) override;
     void load_tool_list(const cmnPath & path,
                         const std::string & indexFile = "tool/index.json");

--- a/core/components/include/sawIntuitiveResearchKit/mtsIntuitiveResearchKitSUJ.h
+++ b/core/components/include/sawIntuitiveResearchKit/mtsIntuitiveResearchKitSUJ.h
@@ -26,12 +26,14 @@ http://www.cisst.org/cisst/license.txt.
 #include <sawIntuitiveResearchKit/mtsStateMachine.h>
 #include <sawIntuitiveResearchKit/mtsIntuitiveResearchKitControlTypes.h>
 
+#include <cisstParameterTypes/prmSimulationType.h>
+
 #include <sawIntuitiveResearchKit/sawIntuitiveResearchKitExport.h>
 
 // forward declaration
 class mtsIntuitiveResearchKitSUJArmData;
 
-class CISST_EXPORT mtsIntuitiveResearchKitSUJ: public mtsTaskPeriodic
+class CISST_EXPORT mtsIntuitiveResearchKitSUJ: public mtsTaskPeriodic, public prmSimulationType
 {
     CMN_DECLARE_SERVICES(CMN_DYNAMIC_CREATION_ONEARG, CMN_LOG_ALLOW_DEFAULT);
 
@@ -48,7 +50,8 @@ class CISST_EXPORT mtsIntuitiveResearchKitSUJ: public mtsTaskPeriodic
     void Run(void);
     void Cleanup(void);
 
-    void set_simulated(void);
+    // Override from prmSimulationType for handling simulation mode in derived classes
+    virtual void SetSimulationMode(const prmSimulationType::SimulationType& mode) override;
 
  protected:
 
@@ -164,9 +167,6 @@ class CISST_EXPORT mtsIntuitiveResearchKitSUJ: public mtsTaskPeriodic
     vctDoubleVec m_voltages;
     vctFixedSizeVector<mtsIntuitiveResearchKitSUJArmData *, 4> m_sarms;
     size_t m_reference_arm_index; // arm used to provide base frame to all other SUJ arms, traditionally the ECM
-
-    // Flag to determine if this is connected to actual IO/hardware or simulated
-    bool m_simulated = false;
 
     void dispatch_error(const std::string & message);
     void dispatch_warning(const std::string & message);

--- a/core/components/include/sawIntuitiveResearchKit/mtsIntuitiveResearchKitSUJSi.h
+++ b/core/components/include/sawIntuitiveResearchKit/mtsIntuitiveResearchKitSUJSi.h
@@ -27,6 +27,9 @@ http://www.cisst.org/cisst/license.txt.
 #include <cisstParameterTypes/prmEventButton.h>
 #include <cisstParameterTypes/prmPositionCartesianGet.h>
 #include <cisstParameterTypes/prmOperatingState.h>
+
+#include <cisstParameterTypes/prmSimulationType.h>
+
 #include <sawIntuitiveResearchKit/mtsStateMachine.h>
 #include <sawIntuitiveResearchKit/mtsIntuitiveResearchKitControlTypes.h>
 
@@ -36,7 +39,7 @@ http://www.cisst.org/cisst/license.txt.
 class mtsIntuitiveResearchKitSUJSiArduino;
 class mtsIntuitiveResearchKitSUJSiArmData;
 
-class CISST_EXPORT mtsIntuitiveResearchKitSUJSi: public mtsTaskPeriodic
+class CISST_EXPORT mtsIntuitiveResearchKitSUJSi: public mtsTaskPeriodic, public prmSimulationType
 {
     CMN_DECLARE_SERVICES(CMN_DYNAMIC_CREATION_ONEARG, CMN_LOG_ALLOW_DEFAULT);
 
@@ -53,9 +56,10 @@ class CISST_EXPORT mtsIntuitiveResearchKitSUJSi: public mtsTaskPeriodic
     void Run(void);
     void Cleanup(void);
 
-    void set_simulated(void);
+    // Override from prmSimulationType for handling simulation mode in derived classes
+    virtual void SetSimulationMode(const prmSimulationType::SimulationType &mode) override;
 
- protected:
+  protected:
 
     void init(void);
 
@@ -105,9 +109,6 @@ class CISST_EXPORT mtsIntuitiveResearchKitSUJSi: public mtsTaskPeriodic
     // SUJ arms
     vctFixedSizeVector<mtsIntuitiveResearchKitSUJSiArmData *, 4> m_sarms;
     size_t m_reference_arm_index; // arm used to provide base frame to all other SUJ arms, traditionally the ECM
-
-    // Flag to determine if this is connected to actual IO/hardware or simulated
-    bool m_simulated = false;
 
     void dispatch_error(const std::string & message);
     void dispatch_warning(const std::string & message);


### PR DESCRIPTION
Hello @adeguet1,
This pull request changes the logic for handling simulation mode. The classes impacted by the changes are: `mtsIntuitiveResearchKitArm`, `mtsIntuitiveResearchKitECM`, `mtsIntuitiveResearchKitMTM`, `mtsIntuitiveResearchKitPSM`, `mtsIntuitiveResearchKitSUJ`, `mtsIntuitiveResearchKitSUJSi`.